### PR TITLE
Add an option to allow unrecognized options

### DIFF
--- a/src/main/java/com/sampullara/cli/Args.java
+++ b/src/main/java/com/sampullara/cli/Args.java
@@ -47,11 +47,12 @@ public class Args {
     /**
      * Parse a set of arguments and populate the target with the appropriate values.
      *
-     * @param target Either an instance or a class
-     * @param args   The arguments you want to parse and populate
+     * @param target            Either an instance or a class
+     * @param args              The arguments you want to parse and populate
+     * @param allowUnrecognized Whether or not you want to only allow defined arguments
      * @return The list of arguments that were not consumed
      */
-    public static List<String> parse(Object target, String[] args) {
+    public static List<String> parse(Object target, String[] args, boolean allowUnrecognized) {
         List<String> arguments = new ArrayList<String>();
         arguments.addAll(Arrays.asList(args));
         Class<?> clazz;
@@ -76,13 +77,16 @@ public class Args {
             }
         }
 
-        for (String argument : arguments) {
-            if (argument.startsWith("-")) {
-                throw new IllegalArgumentException("Invalid argument: " + argument);
-            }
+        if (!allowUnrecognized) {
+            for (String argument : arguments) {
+                if (argument.startsWith("-")) {
+                    throw new IllegalArgumentException("Invalid argument: " + argument);
+                }
+            }    
         }
         return arguments;
     }
+    public static List<String> parse(Object target, String[] args) { return parse(target, args, false); }
 
     private static void processField(Object target, Field field, List<String> arguments) {
         Argument argument = field.getAnnotation(Argument.class);


### PR DESCRIPTION
Sometimes, it is nice to have the unrecognized options as a part of the arguments list - so you can (for example) pass them to a subprocess.  This patch allows that.
