### PR TITLE
possibility to declare a main class for usage

### DIFF
--- a/src/main/java/com/sampullara/cli/Args.java
+++ b/src/main/java/com/sampullara/cli/Args.java
@@ -213,13 +213,24 @@ public class Args {
      * @param target    An instance or class.
      */
     public static void usage(PrintStream errStream, Object target) {
+        usage(errStream, target, (target instanceof Class)?(Class)target:target.getClass());
+    }
+    
+    /**
+     * Generate usage information based on the target annotations.
+     *
+     * @param errStream A {@link java.io.PrintStream} to print the usage information to.
+     * @param target    An instance or class.
+     * @param mainClass The class containing the main method
+     */
+    public static void usage(PrintStream errStream, Object target, Class mainClass) {
         Class<?> clazz;
         if (target instanceof Class) {
             clazz = (Class) target;
         } else {
             clazz = target.getClass();
         }
-        errStream.println("Usage: " + clazz.getName());
+        errStream.println("Usage: " + mainClass.getName());
         for (Class<?> currentClazz = clazz; currentClazz != null; currentClazz = currentClazz.getSuperclass()) {
             for (Field field : currentClazz.getDeclaredFields()) {
                 fieldUsage(errStream, target, field);

--- a/src/test/java/com/sampullara/cli/ArgsTest.java
+++ b/src/test/java/com/sampullara/cli/ArgsTest.java
@@ -3,7 +3,10 @@ package com.sampullara.cli;
 import junit.framework.TestCase;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.List;
 
 /**
@@ -109,6 +112,27 @@ public class ArgsTest extends TestCase {
         Args.parse(tc, args);
         assertTrue(tc.help);
         assertTrue(tc.verbose);
+    }
+
+    
+    public void testUsageShowsParameterClassByDefault() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        Args.usage(ps, Example.class);
+        
+        ps.flush();
+        String usage = new String(baos.toByteArray());
+        assertTrue(usage.startsWith("Usage: " + Example.class.getName()));
+    }
+    
+    public void testUsageShowsGivenMainClass() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        Args.usage(ps, Example.class, ArgsTest.class);
+        
+        ps.flush();
+        String usage = new String(baos.toByteArray());
+        assertTrue(usage.startsWith("Usage: " + ArgsTest.class.getName()));
     }
 
     public static class TestCommand {


### PR DESCRIPTION
When we separate arguments class from the main class the usage is wrong.
This PR provides the possibility to use a `usage` method for which the program main class is given so that usage message references this given main class and not the parameter one.
